### PR TITLE
support package to work across different databases, fix deleteAllResumeTokens, added few more methods

### DIFF
--- a/examples/react-todos/.meteor/packages
+++ b/examples/react-todos/.meteor/packages
@@ -5,6 +5,7 @@
 # but you can also edit it by hand.
 
 less
+accounts-password-pg-driver
 accounts-password
 reactive-var
 meteorhacks:npm

--- a/packages/accounts-base-pg-driver/accounts-base-pg-driver.js
+++ b/packages/accounts-base-pg-driver/accounts-base-pg-driver.js
@@ -5,6 +5,18 @@ AccountsDBClientPG = class AccountsDBClientPG {
     this.Services = new PG.Table("users_services");
   }
 
+  // format the userID to the datatype used by storage backend
+  // e.g. postgres is using userId as an integer
+  formatUserIdToDbType(userId) {
+    return parseInt(currentInvocation.userId, 10);
+  }
+  
+  //DDP assumes user ids are strings
+  formatUserIdToDdpType(userId) {
+    return userId + "";
+  }
+  
+  
   insertUser() {
     const result = PG.await(this.Users.knex().insert({}).returning("id"));
     return result[0];

--- a/packages/accounts-base/accounts_server.js
+++ b/packages/accounts-base/accounts_server.js
@@ -98,7 +98,8 @@ Ap.userId = function () {
 
   // XXX DDP assumes user IDs are strings
   if (currentInvocation.userId) {
-    return parseInt(currentInvocation.userId, 10);
+    return this.dbClient.formatUserIdToDbType(
+                            currentInvocation.userId);
   } else {
     return currentInvocation.userId;
   }
@@ -279,7 +280,7 @@ Ap._loginUser = function (methodInvocation, userId, stampedLoginToken) {
   });
 
   // DDP assumes user ids are strings
-  methodInvocation.setUserId(userId + "");
+  methodInvocation.setUserId(this.dbClient.formatUserIdToDdpType(userId));
 
   return {
     id: userId,

--- a/packages/accounts-base/package.js
+++ b/packages/accounts-base/package.js
@@ -4,11 +4,6 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
-  api.use([
-    'accounts-base-pg-driver',
-    'simple:pg'
-  ], ['server']);
-
   api.use('underscore', ['client', 'server']);
   api.use('ddp-rate-limiter');
   api.use('localstorage', 'client');

--- a/packages/accounts-password/package.js
+++ b/packages/accounts-password/package.js
@@ -11,8 +11,7 @@ Package.onUse(function(api) {
     'srp',
     'sha',
     'ejson',
-    'ddp',
-    'accounts-password-pg-driver'
+    'ddp'
   ], ['client', 'server']);
 
   // Export Accounts (etc) to packages using this one.


### PR DESCRIPTION
hi Guys,
first off thanks for this effort to use other backends for meteor-accounts.

1 - I have attempted to see if with some small changes, can make this pluggable to work with any supported backend db. I defined a variable (Meteor.AccountsDBClient)in accounts-base-pg-driver that is set to the interface class and then accounts-base uses that variable to instantiate the required class.

 This currently requires that 'accounts-password-pg-driver' is defined before accounts-password in the app's packages (i tried to overcome this by having accounts-base-pg-driver 'use' accounts-base, but that causes circular dependencies)

p.s not claiming this is best or final, but wanted to make a start on your super effort and extend it to [couchdb](https://github.com/mariobriggs/meteor-accounts-couchdb), since we had a few requests for this. So thanks to you.

2 - added methods in the 'AccountsDBClientPG' for moving out the 'observes' on users & users-services (setupObserves, stopObserves).
 Also add a few more methods (removeOtherHashedLoginTokens, expireResumeTokens, updatePassword) in the interface and ensured it is invoked via that from password-server.js and accounts-server.js

3- small fix to deleteAllResumeTokens and added the userId parameter, so can be used even when required to delete for a particular user
