### PR TITLE
Fix for addAssets allowing backwards compatibility pre 1.2

### DIFF
--- a/packages/pg/package.js
+++ b/packages/pg/package.js
@@ -41,11 +41,19 @@ Package.onUse(function(api) {
   api.use(['underscore', 'ddp-server'], 'server');
   api.addFiles(['observe-driver/polling-driver.js'], 'server');
 
-  api.addAssets([
-    'observe-driver/setup-triggers.sql',
-    'observe-driver/poll-n-diff.sql',
-    'observe-driver/poll.sql'
-  ], 'server');
+  if (api.addAssets) {
+    api.addAssets([
+      'observe-driver/setup-triggers.sql',
+      'observe-driver/poll-n-diff.sql',
+      'observe-driver/poll.sql'
+    ], 'server');
+  } else {
+    api.addFiles([
+      'observe-driver/setup-triggers.sql',
+      'observe-driver/poll-n-diff.sql',
+      'observe-driver/poll.sql'
+    ], 'server', { isAsset: true });
+  }
 
   api.addFiles([
     'pg.js',


### PR DESCRIPTION
Check for `api.addAssets` in `package.js` and fallback to `api.addFiles` with isAsset: true if not found.
