### PR TITLE
Missing .knex/package.json

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,9 @@ git clone https://github.com/meteor/postgres-packages.git
 # Set up Knex CLI tool
 cd postgres-packages/examples/react-todos/.knex/
 npm install -g knex
+## If you do not have package.json in in this folder, type the following command and answer a bunch of questions
+# npm init 
+## else just type
 npm install
 
 # Create database and run migrations


### PR DESCRIPTION
.knex/package.json is not created when you perform `npm install -g knex` and `npm install`. 

Sample `package.json` is

```
{
  "name": "knex",
  "version": "1.0.0",
  "description": "Run the knex CLI inside here.",
  "main": "knexfile.js",
  "dependencies": {
    "knex": "^0.8.6",
    "pg": "^4.4.1"
  },
  "devDependencies": {},
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "author": "",
  "license": "ISC"
}
```
