### PR TITLE
Get currentInvocation in AccountsDBClientPG

### DIFF
--- a/packages/accounts-base-pg-driver/accounts-base-pg-driver.js
+++ b/packages/accounts-base-pg-driver/accounts-base-pg-driver.js
@@ -8,6 +8,7 @@ AccountsDBClientPG = class AccountsDBClientPG {
   // format the userID to the datatype used by storage backend
   // e.g. postgres is using userId as an integer
   formatUserIdToDbType(userId) {
+    let currentInvocation = DDP._CurrentInvocation.get();
     return parseInt(currentInvocation.userId, 10);
   }
   


### PR DESCRIPTION
AccountsDBClientPG.formatUserIdToDbType was throwing an error about currentInvocation undefined.

Now setting currentInvocation to DDP._CurrentInvocation.get()
